### PR TITLE
bug fixed when processing the 'fuelrod' input

### DIFF
--- a/B0_control.py
+++ b/B0_control.py
@@ -352,7 +352,7 @@ class Control:
                                 x['kr'].append(float(word[9]))
                                 x['kz'].append(float(word[10]))
                     else:
-                        inp['fuelrod'].append({'id':id, 'fuelid':[word[2]], 'hgap':[float(word[3])], 'cladid':[word[4]], 'p2d':[float(word[5])], 'mltpl':[float(word[6])], 'pipeid':[word[7]], 'pipenode':[int(word[8])], 'kr':[float(word[9])], 'kz':float(word[10])})
+                        inp['fuelrod'].append({'id':id, 'fuelid':[word[2]], 'hgap':[float(word[3])], 'cladid':[word[4]], 'p2d':[float(word[5])], 'mltpl':[float(word[6])], 'pipeid':[word[7]], 'pipenode':[int(word[8])], 'kr':[float(word[9])], 'kz':[float(word[10])]})
                 #--------------------------------------------------------------------------------------
                 # heat structure card
                 elif key == 'htstr':

--- a/B1B0_fuel.py
+++ b/B1B0_fuel.py
@@ -31,7 +31,7 @@ class Fuel:
         # number of fuel radial nodes
         self.nr = list[i]['nr']
         # axial power peaking factor of fuel
-        self.kz = list[i]['kz']
+        self.kz = dictfuelrod['kz'][indx]
 
         # fuel material id
         matid = list[i]['matid']


### PR DESCRIPTION
Hi professor, 'kz' need to be a list, not a float number.